### PR TITLE
Fix SCSS entrypoint and theme variable definitions

### DIFF
--- a/src/breakouts.scss
+++ b/src/breakouts.scss
@@ -1,4 +1,4 @@
 // Project: Breakouts entry point
 // Description: This file is the entry point for the Breakouts module.
 
-@forward 'src/index';
+@forward 'index';

--- a/src/theme/_chupa-pop.scss
+++ b/src/theme/_chupa-pop.scss
@@ -4,9 +4,9 @@
 // The theme variables are used to customize the appearance of the Chupa Pop theme.
 // The theme variables are defined using the SCSS @use and @forward directives.
 
-$color-primary: #ecb838 !default;
-$color-secondary: #ab4073 !default;
-$color-accent: #196484 !default;
+$primary: #ecb838 !default;
+$secondary: #ab4073 !default;
+$accent: #196484 !default;
 
 @forward 'breakouts/src/theme/variables' with (
   $color-primary: $primary,

--- a/src/theme/_medical.scss
+++ b/src/theme/_medical.scss
@@ -10,7 +10,8 @@ $accent: #A9A9A9 !default;
 $muted: #D3D3D3 !default;
 $background: #FFFFFF !default;
 
-@forward 'breakouts/src/theme/variables'with ($color-primary: $primary,
+@forward 'breakouts/src/theme/variables' with (
+    $color-primary: $primary,
     $color-primary-dark: darken($primary, 15%),
     $color-primary-light: lighten($primary, 15%),
 
@@ -28,9 +29,10 @@ $background: #FFFFFF !default;
 
     $color-background: $background,
     $color-background-dark: darken($background, 5%),
-    $color-background-light: lighten($background, 5%));
+    $color-background-light: lighten($background, 5%)
+);
 
-@use 'breakouts/src/theme/variables'as *;
+@use 'breakouts/src/theme/variables' as *;
 @forward 'breakouts/src/theme/colors';
 @forward 'breakouts/src/base/reset';
 @forward 'breakouts/src/base/typography';


### PR DESCRIPTION
## Summary
- correct the SCSS entrypoint to forward the local index file
- align Chupa Pop theme variable definitions with the names used in the forwarded configuration
- tidy Medical theme forwarding syntax for readability and consistency

## Testing
- npm run build *(fails: sass dependency unavailable because the registry returned 403 Forbidden)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924728fb8f483218e8ca2c9d32407f7)